### PR TITLE
Attach doc comments to struct fields, union cases and enum cases in java

### DIFF
--- a/haskell/compiler/adlc-lib1/ADL/Compiler/Backends/Java.hs
+++ b/haskell/compiler/adlc-lib1/ADL/Compiler/Backends/Java.hs
@@ -203,7 +203,7 @@ generateCoreStruct codeProfile moduleName javaPackageFn decl struct =  gen
              (if cgp_publicMembers codeProfile then ["public"] else ["private"])
              <>
              (if cgp_mutable codeProfile then [] else ["final"])
-        addField (ctemplate "$1 $2 $3;" [T.intercalate " " modifiers,fd_typeExprStr fd,fd_memberVarName fd])
+        addField (generateDocString (f_annotations (fd_field fd)) <> ctemplate "$1 $2 $3;" [T.intercalate " " modifiers,fd_typeExprStr fd,fd_memberVarName fd])
 
       -- Constructors
       let ctorAllArgs = T.intercalate ", " [fd_typeExprStr fd <> " " <> fd_varName fd | fd <- fieldDetails]
@@ -470,7 +470,7 @@ generateUnion codeProfile moduleName javaPackageFn decl union =  execState gen s
             docStringComment (template "The $1 discriminator type." [className])
             <>
             cblock "public enum Disc" (
-              mconcat [ctemplate "$1$2" [discriminatorName fd,term]
+              mconcat [generateDocString (f_annotations (fd_field fd)) <> ctemplate "$1$2" [discriminatorName fd,term]
                       | (fd,term) <- zip fieldDetails terminators]
                )
       addMethod discdef
@@ -708,7 +708,7 @@ generateEnum codeProfile moduleName javaPackageFn decl union = execState gen sta
       factoryInterface <- addImport (javaClass (cgp_runtimePackage codeProfile) "Factory")
 
       let terminators = replicate (length fieldDetails-1) "," <> [";"]
-      mapM_ addField [ctemplate "$1$2" [discriminatorName fd,term] | (fd,term) <- zip fieldDetails terminators]
+      mapM_ addField [generateDocString (f_annotations (fd_field fd)) <> ctemplate "$1$2" [discriminatorName fd,term] | (fd,term) <- zip fieldDetails terminators]
 
       addMethod $ coverride "public String toString()" (
         cblock "switch(this)" (

--- a/haskell/compiler/tests/test29/java-output/adl/test29/Test.java
+++ b/haskell/compiler/tests/test29/java-output/adl/test29/Test.java
@@ -24,6 +24,9 @@ public class Test {
 
   /* Members */
 
+  /**
+   * "foo" as a field
+   */
   private Map<String, String> foo;
 
   /* Constructors */

--- a/haskell/compiler/tests/test3/input/test.adl
+++ b/haskell/compiler/tests/test3/input/test.adl
@@ -24,6 +24,7 @@ struct B<T>
 
 union U
 {
+   /// An integer
    Int16 f_int;
    String f_string;
    Void f_void;
@@ -31,6 +32,7 @@ union U
 
 union E
 {
+   /// value 1
    Void v1;
    Void v2;
 };

--- a/haskell/compiler/tests/test3/java-output/adl/test3/E.java
+++ b/haskell/compiler/tests/test3/java-output/adl/test3/E.java
@@ -18,6 +18,9 @@ public enum E {
 
   /* Members */
 
+  /**
+   * value 1
+   */
   V1,
   V2;
 

--- a/haskell/compiler/tests/test3/java-output/adl/test3/U.java
+++ b/haskell/compiler/tests/test3/java-output/adl/test3/U.java
@@ -27,6 +27,9 @@ public class U {
    * The U discriminator type.
    */
   public enum Disc {
+    /**
+     * An integer
+     */
     F_INT,
     F_STRING,
     F_VOID

--- a/haskell/compiler/tests/test3/rs-output/test3/adl/test3.rs
+++ b/haskell/compiler/tests/test3/rs-output/test3/adl/test3.rs
@@ -69,6 +69,9 @@ impl<T> B<T> {
 
 #[derive(Clone,Deserialize,Eq,Hash,PartialEq,Serialize)]
 pub enum U {
+  /**
+   * An integer
+   */
   #[serde(rename="f_int")]
   FInt(i16),
 
@@ -81,6 +84,9 @@ pub enum U {
 
 #[derive(Clone,Deserialize,Eq,Hash,PartialEq,Serialize)]
 pub enum E {
+  /**
+   * value 1
+   */
   #[serde(rename="v1")]
   V1,
 

--- a/haskell/compiler/tests/test3/ts-output/test3.ts
+++ b/haskell/compiler/tests/test3/ts-output/test3.ts
@@ -104,6 +104,9 @@ export interface U_F_void {
 export type U = U_F_int | U_F_string | U_F_void;
 
 export interface UOpts {
+  /**
+   * An integer
+   */
   f_int: number;
   f_string: string;
   f_void: null;


### PR DESCRIPTION
Adds doc-comments in java for members. 

### Motivation
- IDEs make it easy to browse/navigate java files, but tricky to jump to ADL definitions. This change makes it easier to see doc-comments for generated types.
- Coding agents are unreliable about bringing in relevant .adl files into scope when reading generated java files, even with configured rules. This is a sure-fire way to bring helpful doc-comments into a coding agent's context.

### Design
For struct members, we add the doc-comment to the field. It would be possible to also annotate the getters/setters, but I leave that as follow-up.

For union members, we add the doc-comment to the enum cases, or the discriminator enum's cases. Similarly we could extend the generation to add doc-comments to java methods, but this is left as future work.

### Tests
Extend golden tests to demonstrate the changes.

To see how this would affect the internal codebase, see phab D91253.